### PR TITLE
Fix: rewrite to CommonJS for Node 18 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@
  * MCP Bridge — universal stdio-to-HTTP proxy for Claude Desktop.
  *
  * Usage:
- *   npx phasetransitions-mcp-bridge <url> <password>
+ *   node index.js <url> <password>
  *
  * Claude Desktop launches this as a stdio process. Every JSON-RPC message
  * from stdin is POSTed to the remote /mcp endpoint. The response is written
  * back to stdout. Zero dependencies — uses only Node built-in modules.
  */
 
-import { createInterface } from "node:readline";
-import { Buffer } from "node:buffer";
+const { createInterface } = require("node:readline");
+const { Buffer } = require("node:buffer");
 
 const url = process.argv[2];
 const password = process.argv[3];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": {
     "mcp-bridge": "index.js"
   },
-  "type": "module",
+
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary
Rewrites `index.js` from ES module syntax (`import`) to CommonJS (`require`).
Removes `"type": "module"` from `package.json`. Fixes #4.

## Root cause
The installer downloads `index.js` to `~/mcp-bridge/` — a bare directory
with no `package.json`. Node 18 defaults to CommonJS and crashes on `import`.

## Tested
- Node 18.20.7 from bare `~/mcp-bridge/` directory: starts, responds to
  JSON-RPC initialize, returns valid response with protocolVersion and serverInfo
- Node 24.13.1 from bare `~/mcp-bridge/` directory: same result
- Both tested by piping a real initialize message and verifying stdout output

## Next step
Merge, then test Step 3 from the install plan: open Claude Desktop and
verify legalsearch tools appear.

Made with [Cursor](https://cursor.com)